### PR TITLE
chore: add docker compose override for local development

### DIFF
--- a/compose.override.yml
+++ b/compose.override.yml
@@ -1,0 +1,6 @@
+services:
+  mntsrv:
+    # Use local build context for development
+    build: .
+    # Optionally, you can override or add more dev-specific settings here
+    # image: is overridden by build:

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   mntsrv:
-    build: .
+    image: ghcr.io/romeniwebdesign/mntsrv:v0.1.0
     container_name: mntsrv
     environment:
       - ADMIN_USER=${ADMIN_USER}


### PR DESCRIPTION
This pull request introduces changes to the Docker Compose configuration to differentiate between development and production environments. It adds a development-specific override file and modifies the main configuration to use a pre-built image for production.

### Environment-specific Docker Compose configuration:

* [`compose.override.yml`](diffhunk://#diff-01e2a36d1d89495fcee43db58f09c523cfd80a652e4b547fc739bfa215365cb2R1-R6): Added a new override file for development, specifying the use of a local build context for the `mntsrv` service. This allows developers to build the service locally during development.

* [`compose.yml`](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L3-R3): Updated the main configuration to use a pre-built Docker image (`ghcr.io/romeniwebdesign/mntsrv:v0.1.0`) for the `mntsrv` service in production, replacing the local build context.