### PR TITLE
fix: dockerignore irgnoring things

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 # Node/React
 frontend/node_modules
-frontend/build
+# frontend/build
 npm-debug.log
 
 # Python


### PR DESCRIPTION
This pull request makes a minor adjustment to the `.dockerignore` file to fix a formatting issue by adding a missing space before the `frontend/build` entry. 

* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5L3-R3): Corrected the formatting by adding a space before the `frontend/build` entry to ensure consistency with the other entries.