### PR TITLE
fix: issue with scanning progress

### DIFF
--- a/frontend/src/FolderBrowser.js
+++ b/frontend/src/FolderBrowser.js
@@ -136,7 +136,14 @@ function FolderBrowser({ token }) {
       {scanStatus && scanStatus.status !== "idle" && scanStatus.done === false && (
         <div className="mb-3">
           <div>
-            <b>Scan läuft:</b> {scanStatus.scanned} / {scanStatus.total} ({Math.round((scanStatus.scanned / scanStatus.total) * 100)}%)
+            {(() => {
+              const percent = scanStatus.total > 0 ? Math.round((scanStatus.scanned / scanStatus.total) * 100) : 0;
+              return (
+                <div>
+                  <b>Scan läuft:</b> {scanStatus.scanned} / {scanStatus.total} ({percent}%)
+                </div>
+              );
+            })()}
           </div>
           <div className="progress" style={{ height: 20 }}>
             <div

--- a/frontend/src/SharesModal.js
+++ b/frontend/src/SharesModal.js
@@ -71,9 +71,14 @@ function SharesModal({ token, show, onClose }) {
         {/* Fortschrittsanzeige für Scan */}
         {scanStatus && scanStatus.status !== "idle" && scanStatus.done === false && (
           <div className="mb-3">
-            <div>
-              <b>Scan läuft:</b> {scanStatus.scanned} / {scanStatus.total} ({Math.round((scanStatus.scanned / scanStatus.total) * 100)}%)
-            </div>
+            {(() => {
+              const percent = scanStatus.total > 0 ? Math.round((scanStatus.scanned / scanStatus.total) * 100) : 0;
+              return (
+                <div>
+                  <b>Scan läuft:</b> {scanStatus.scanned} / {scanStatus.total} ({percent}%)
+                </div>
+              );
+            })()}
             <div className="progress" style={{ height: 20 }}>
               <div
                 className="progress-bar progress-bar-striped progress-bar-animated"

--- a/frontend/src/SharesPage.js
+++ b/frontend/src/SharesPage.js
@@ -67,7 +67,14 @@ function SharesPage({ token }) {
         {scanStatus && scanStatus.status !== "idle" && scanStatus.done === false && (
           <div className="mb-3">
             <div>
-              <b>Scan läuft:</b> {scanStatus.scanned} / {scanStatus.total} ({Math.round((scanStatus.scanned / scanStatus.total) * 100)}%)
+              {(() => {
+                const percent = scanStatus.total > 0 ? Math.round((scanStatus.scanned / scanStatus.total) * 100) : 0;
+                return (
+                  <div>
+                    <b>Scan läuft:</b> {scanStatus.scanned} / {scanStatus.total} ({percent}%)
+                  </div>
+                );
+              })()}
             </div>
             <div className="progress" style={{ height: 20 }}>
               <div


### PR DESCRIPTION
This pull request improves the handling of progress percentage calculations in multiple components by introducing a safeguard against division by zero. The changes ensure that the progress percentage is calculated only when the total value is greater than zero, enhancing the robustness of the UI.

### Improvements to progress calculation:

* [`frontend/src/FolderBrowser.js`](diffhunk://#diff-212c58a52ff3a28a8b44036b257930b48a05ec518d2874f143606215815478abL139-R146): Wrapped the progress percentage calculation in a self-invoking function to handle cases where `scanStatus.total` is zero, avoiding potential division by zero errors.

* [`frontend/src/SharesModal.js`](diffhunk://#diff-399517e43cf2ac108babce4c91b89d48164a90a09cf9490f59f0bd354fb0dd47R74-R81): Updated the progress display logic to use a self-invoking function for safer percentage calculation, ensuring `scanStatus.total > 0` before performing the division.

* [`frontend/src/SharesPage.js`](diffhunk://#diff-36b36c7c6ddb0d5147022b02b6149f49858ddb39ff3a04376e600f7d9695bd6bL70-R77): Refactored the progress percentage calculation similarly, adding a check for `scanStatus.total > 0` to prevent division by zero.