### PR TITLE
add hours and days to expired

### DIFF
--- a/frontend/src/ShareForm.js
+++ b/frontend/src/ShareForm.js
@@ -3,7 +3,8 @@ import { Form, Button, Alert, InputGroup, Modal } from "react-bootstrap";
 
 function ShareForm({ token, path, onClose }) {
   const [password, setPassword] = useState("");
-  const [expiresIn, setExpiresIn] = useState(60); // Minuten
+  const [expiresIn, setExpiresIn] = useState(60); // Value in the selected unit
+  const [timeUnit, setTimeUnit] = useState("minutes"); // minutes, hours, days
   const [shareUrl, setShareUrl] = useState("");
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -16,7 +17,16 @@ function ShareForm({ token, path, onClose }) {
       const params = new URLSearchParams();
       params.append("path", path);
       if (password) params.append("password", password);
-      params.append("expires_in", expiresIn * 60);
+      
+      // Convert to minutes based on selected unit
+      let expiresInMinutes = expiresIn;
+      if (timeUnit === "hours") {
+        expiresInMinutes = expiresIn * 60;
+      } else if (timeUnit === "days") {
+        expiresInMinutes = expiresIn * 60 * 24;
+      }
+      
+      params.append("expires_in", expiresInMinutes * 60); // Backend expects seconds
       const res = await fetch(`/api/share?${params.toString()}`, {
         method: "POST",
         headers: { Authorization: `Bearer ${token}` },
@@ -63,7 +73,7 @@ function ShareForm({ token, path, onClose }) {
             </div>
           </Form.Group>
           <Form.Group className="mb-3">
-            <Form.Label>Ablaufzeit (Minuten)</Form.Label>
+            <Form.Label>Ablaufzeit</Form.Label>
             <InputGroup>
               <Form.Control
                 type="number"
@@ -71,7 +81,15 @@ function ShareForm({ token, path, onClose }) {
                 value={expiresIn}
                 onChange={(e) => setExpiresIn(Number(e.target.value))}
               />
-              <InputGroup.Text>min</InputGroup.Text>
+              <Form.Select
+                value={timeUnit}
+                onChange={(e) => setTimeUnit(e.target.value)}
+                style={{ maxWidth: "120px" }}
+              >
+                <option value="minutes">Minuten</option>
+                <option value="hours">Stunden</option>
+                <option value="days">Tage</option>
+              </Form.Select>
             </InputGroup>
           </Form.Group>
           {error && <Alert variant="danger">{error}</Alert>}


### PR DESCRIPTION
This pull request enhances the `ShareForm` component in `frontend/src/ShareForm.js` by introducing support for multiple time units (minutes, hours, and days) when setting expiration times. The changes improve user flexibility and ensure proper conversion of time units for backend compatibility.

### Enhancements to expiration time functionality:

* Added a new `timeUnit` state to track the selected time unit (minutes, hours, or days) and updated the default comment for `expiresIn` to reflect the selected unit. (`[frontend/src/ShareForm.jsL6-R7](diffhunk://#diff-d69a5dada77d3cb798943cb8d3f6d0af10ac9d85c376b6b496e4238df1a4529bL6-R7)`)
* Implemented logic to convert the `expiresIn` value to minutes based on the selected time unit (e.g., hours or days) before sending it to the backend in seconds. (`[frontend/src/ShareForm.jsL19-R29](diffhunk://#diff-d69a5dada77d3cb798943cb8d3f6d0af10ac9d85c376b6b496e4238df1a4529bL19-R29)`)
* Updated the expiration time input field to include a dropdown for selecting the time unit, replacing the static "min" text with a dynamic `Form.Select` element for user selection. (`[frontend/src/ShareForm.jsL66-R92](diffhunk://#diff-d69a5dada77d3cb798943cb8d3f6d0af10ac9d85c376b6b496e4238df1a4529bL66-R92)`)